### PR TITLE
[REFACTORING] refs #104632, change module active_job to class because module does not derive from Class

### DIFF
--- a/lib/trailblazer/active_job.rb
+++ b/lib/trailblazer/active_job.rb
@@ -5,6 +5,6 @@ require 'trailblazer/active_job/version'
 require 'trailblazer/active_job/base'
 
 module Trailblazer
-  module ActiveJob
+  class ActiveJob
   end
 end

--- a/lib/trailblazer/active_job/version.rb
+++ b/lib/trailblazer/active_job/version.rb
@@ -1,5 +1,5 @@
 module Trailblazer
-  module ActiveJob
+  class ActiveJob
     VERSION = '1.0.0'.freeze
   end
 end


### PR DESCRIPTION
Sorbet complains about Trailblazer::ActiveJob::Base is a module and therefor does not derive from class.
https://sorbet.org/docs/error-reference#5067 